### PR TITLE
Update setup.py   Wrong relative path in package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'ordered-set'
     ],
     extras_require=extras,
-    package_data={'torchmeta': ['torchmeta/datasets/assets/*']},
+    package_data={'torchmeta': ['datasets/assets/*']},
     include_package_data=True,
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
that is a rong way to wrong relative path 
# Before 
package_data={'torchmeta': ['torchmeta/datasets/assets/*']},

# After   that is correct way in code 
package_data={'torchmeta': ['datasets/assets/*']},